### PR TITLE
Implement local PII scrubber

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,28 @@
 # redactory
 
-A privacy-first JavaScript package that redacts Personally Identifiable Information (PII) such as names, emails, dates, and locations using spaCy — powered by WebAssembly and Pyodide, running entirely in the browser.
+A privacy-first Node.js package that detects and masks sensitive information such as emails, phone numbers and SSNs. All processing happens locally with no network access.
 
----
+## Features
 
-## ✨ Features
+- Detects EMAIL, PHONE, SSN and ICD10 codes using regular expressions
+- Policy driven actions (MASK, REDACT, ALLOW)
+- Streaming transform for large data
+- CLI commands: `scrub`, `preview`, `ingest`, `policy validate`
 
-- 🔍 Entity detection via spaCy (`en_core_web_sm`)
-- 🧠 No server required — fully client-side using WebAssembly (via Pyodide)
-- 🚫 Redacts PII by replacing it with `[REDACTED]`
-- ⚡ Optimized for asynchronous use (lazy initialization and worker threads)
-- 📦 Publishable as an npm package
+## Installation
 
----
-
-## 🚀 Installation
-
-```bash
-npm install @redactory/core
 ```
-## 🚀 Installation (Pro Tier)
-
-```bash
-npm install @redactory/pro
+npm install redactory
 ```
 
-## 🚀 Usage
+## Usage
 
 ```javascript
-import { init, redact } from "@redactory/core";
+import { Scrubber, loadPolicy } from 'redactory';
 
-await init(); // load spaCy via Pyodide
-const result = await redact("My name is John Doe and my email is john@example.com.");
+const policy = loadPolicy('policy.yaml');
+const scrubber = new Scrubber(policy);
 
+const { result } = scrubber.scrub('Contact me at john@example.com');
 console.log(result);
-// Output: "My name is [REDACTED] and my email is [REDACTED]."
 ```
-
-

--- a/bin/redactory.js
+++ b/bin/redactory.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
+import { join, extname } from 'path';
+import { Scrubber, loadPolicy, validatePolicy } from '../dist/index.js';
+
+function printHelp() {
+  console.log('Usage: redactory <command> [args]');
+  console.log('Commands: scrub <file> | preview <file> | ingest <dir> | policy validate <file>');
+}
+
+async function main() {
+  const [cmd, arg1, arg2] = process.argv.slice(2);
+  if (!cmd) return printHelp();
+  if (cmd === 'policy' && arg1 === 'validate') {
+    const policy = loadPolicy(arg2 || 'policy.yaml');
+    const errors = validatePolicy(policy);
+    if (errors.length) {
+      console.error('Policy invalid:', errors.join(', '));
+      process.exitCode = 1;
+    } else {
+      console.log('Policy valid');
+    }
+    return;
+  }
+  const policy = loadPolicy('policy.yaml');
+  const scrubber = new Scrubber(policy);
+
+  if (cmd === 'scrub' && arg1) {
+    const txt = readFileSync(arg1, 'utf8');
+    const { result } = scrubber.scrub(txt);
+    writeFileSync(arg1, result);
+    return;
+  }
+  if (cmd === 'preview' && arg1) {
+    const txt = readFileSync(arg1, 'utf8');
+    const { diff } = scrubber.scrub(txt, { preview: true });
+    console.log(diff);
+    return;
+  }
+  if (cmd === 'ingest' && arg1) {
+    const files = readdirSync(arg1);
+    for (const f of files) {
+      const p = join(arg1, f);
+      if (statSync(p).isFile() && ['.txt', '.html', '.json'].includes(extname(p))) {
+        const txt = readFileSync(p, 'utf8');
+        const { result } = scrubber.scrub(txt);
+        writeFileSync(p, result);
+      }
+    }
+    return;
+  }
+
+  printHelp();
+}
+
+main();

--- a/dist/detectors.d.ts
+++ b/dist/detectors.d.ts
@@ -1,0 +1,9 @@
+export interface Entity {
+    type: string;
+    start: number;
+    end: number;
+    text: string;
+    score: number;
+    ruleId: string;
+}
+export declare function detect(text: string): Entity[];

--- a/dist/detectors.js
+++ b/dist/detectors.js
@@ -1,0 +1,24 @@
+const patterns = [
+    { type: 'EMAIL', regex: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[A-Za-z]{2,}/g, score: 1, ruleId: 'regex-email' },
+    { type: 'PHONE', regex: /\b\d{3}[ -]?\d{3}[ -]?\d{4}\b/g, score: 0.9, ruleId: 'regex-phone' },
+    { type: 'SSN', regex: /\b\d{3}-\d{2}-\d{4}\b/g, score: 0.95, ruleId: 'regex-ssn' },
+    { type: 'ICD10', regex: /[A-TV-Z][0-9][0-9AB](\.[0-9A-TV-Z]{1,4})?/g, score: 0.8, ruleId: 'regex-icd10' }
+];
+export function detect(text) {
+    const entities = [];
+    for (const p of patterns) {
+        for (const match of text.matchAll(p.regex)) {
+            const [value] = match;
+            const start = match.index || 0;
+            entities.push({
+                type: p.type,
+                start,
+                end: start + value.length,
+                text: value,
+                score: p.score,
+                ruleId: p.ruleId
+            });
+        }
+    }
+    return entities.sort((a, b) => a.start - b.start);
+}

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,3 @@
+export { Scrubber } from './scrubber.js';
+export { loadPolicy, validatePolicy } from './policy.js';
+export { ScrubTransform } from './transform.js';

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,3 @@
+export { Scrubber } from './scrubber.js';
+export { loadPolicy, validatePolicy } from './policy.js';
+export { ScrubTransform } from './transform.js';

--- a/dist/policy.d.ts
+++ b/dist/policy.d.ts
@@ -1,0 +1,16 @@
+export interface Policy {
+    version: number;
+    entityTypes: string[];
+    actions: Record<string, 'MASK' | 'REDACT' | 'ALLOW'>;
+    thresholds: {
+        default: number;
+        [key: string]: number;
+    };
+    mask?: {
+        char: string;
+        keepLast: number;
+    };
+    fallback: 'BLOCK' | 'ALLOW' | 'MASK' | 'REDACT';
+}
+export declare function loadPolicy(file: string): Policy;
+export declare function validatePolicy(policy: Policy): string[];

--- a/dist/policy.js
+++ b/dist/policy.js
@@ -1,0 +1,53 @@
+import { readFileSync } from 'fs';
+function parseYaml(text) {
+    const obj = {};
+    const lines = text.split(/\r?\n/);
+    let currentKey = null;
+    for (const line of lines) {
+        if (/^\s*$/.test(line))
+            continue;
+        const m = /^([^:]+):\s*(.*)$/.exec(line);
+        if (m) {
+            const key = m[1].trim();
+            const value = m[2].trim();
+            if (value === '') {
+                currentKey = key;
+                obj[key] = [];
+            }
+            else if (value.startsWith('[')) {
+                obj[key] = JSON.parse(value);
+            }
+            else if (/^(true|false|\d+)$/.test(value)) {
+                obj[key] = JSON.parse(value);
+            }
+            else {
+                obj[key] = value;
+            }
+            continue;
+        }
+        const arr = /^\s+-\s*(.*)$/.exec(line);
+        if (arr && currentKey) {
+            obj[currentKey].push(arr[1].trim());
+        }
+    }
+    return obj;
+}
+export function loadPolicy(file) {
+    const text = readFileSync(file, 'utf8');
+    const data = file.endsWith('.json') ? JSON.parse(text) : parseYaml(text);
+    return data;
+}
+export function validatePolicy(policy) {
+    const errors = [];
+    if (typeof policy.version !== 'number')
+        errors.push('version');
+    if (!Array.isArray(policy.entityTypes))
+        errors.push('entityTypes');
+    if (typeof policy.actions !== 'object')
+        errors.push('actions');
+    if (typeof policy.thresholds !== 'object')
+        errors.push('thresholds');
+    if (!policy.fallback)
+        errors.push('fallback');
+    return errors;
+}

--- a/dist/scrubber.d.ts
+++ b/dist/scrubber.d.ts
@@ -1,0 +1,19 @@
+import { Policy } from './policy.js';
+import { Entity } from './detectors.js';
+export interface ScrubOptions {
+    preview?: boolean;
+    explain?: boolean;
+}
+export interface ScrubResult {
+    result: string;
+    entities?: Entity[];
+    diff?: string;
+}
+export declare class Scrubber {
+    private policy;
+    constructor(policy: Policy);
+    static fromFile(path: string): Scrubber;
+    updatePolicy(policy: Policy): void;
+    scrub(text: string, options?: ScrubOptions): ScrubResult;
+    private inlineDiff;
+}

--- a/dist/scrubber.js
+++ b/dist/scrubber.js
@@ -1,0 +1,82 @@
+import { loadPolicy } from './policy.js';
+import { detect } from './detectors.js';
+import { mask, replaceRange } from './utils.js';
+export class Scrubber {
+    policy;
+    constructor(policy) {
+        this.policy = policy;
+    }
+    static fromFile(path) {
+        const p = loadPolicy(path);
+        return new Scrubber(p);
+    }
+    updatePolicy(policy) {
+        this.policy = policy;
+    }
+    scrub(text, options = {}) {
+        const entities = detect(text);
+        let result = text;
+        let offset = 0;
+        const applied = [];
+        for (const ent of entities) {
+            const threshold = this.policy.thresholds[ent.type] ?? this.policy.thresholds.default;
+            if (ent.score < threshold)
+                continue;
+            const action = this.policy.actions[ent.type] ?? this.policy.fallback;
+            let replacement = ent.text;
+            if (action === 'MASK') {
+                const maskChar = this.policy.mask?.char ?? '*';
+                const keepLast = this.policy.mask?.keepLast ?? 0;
+                replacement = mask(ent.text, maskChar, keepLast);
+            }
+            else if (action === 'REDACT') {
+                replacement = '[REDACTED]';
+            }
+            else if (action === 'ALLOW') {
+                continue;
+            }
+            result = replaceRange(result, ent.start + offset, ent.end + offset, replacement);
+            offset += replacement.length - (ent.end - ent.start);
+            applied.push(ent);
+        }
+        let diff;
+        if (options.preview && result !== text) {
+            diff = this.inlineDiff(text, result);
+        }
+        const res = { result };
+        if (options.explain)
+            res.entities = applied;
+        if (diff)
+            res.diff = diff;
+        return res;
+    }
+    inlineDiff(a, b) {
+        // simple inline diff by marking removed text as [- -] and added as {+ +}
+        let i = 0;
+        let result = '';
+        while (i < a.length || i < b.length) {
+            if (a[i] === b[i]) {
+                result += a[i] ?? '';
+                i++;
+                continue;
+            }
+            const start = i;
+            let endA = start;
+            let endB = start;
+            while (a[endA] !== b[endB] && (endA < a.length || endB < b.length)) {
+                if (a[endA] !== undefined)
+                    endA++;
+                if (b[endB] !== undefined)
+                    endB++;
+                if (a[endA] === b[endB])
+                    break;
+            }
+            if (start !== endA)
+                result += '[-' + a.slice(start, endA) + '-]';
+            if (start !== endB)
+                result += '{+' + b.slice(start, endB) + '+}';
+            i = Math.max(endA, endB);
+        }
+        return result;
+    }
+}

--- a/dist/transform.d.ts
+++ b/dist/transform.d.ts
@@ -1,0 +1,8 @@
+import { Transform } from 'stream';
+import { Scrubber, ScrubOptions } from './scrubber.js';
+export declare class ScrubTransform extends Transform {
+    private scrubber;
+    private options;
+    constructor(scrubber: Scrubber, options?: ScrubOptions);
+    _transform(chunk: any, _enc: any, cb: any): void;
+}

--- a/dist/transform.js
+++ b/dist/transform.js
@@ -1,0 +1,16 @@
+import { Transform } from 'stream';
+export class ScrubTransform extends Transform {
+    scrubber;
+    options;
+    constructor(scrubber, options = {}) {
+        super({ objectMode: true });
+        this.scrubber = scrubber;
+        this.options = options;
+    }
+    _transform(chunk, _enc, cb) {
+        const input = typeof chunk === 'string' ? chunk : chunk.toString();
+        const { result } = this.scrubber.scrub(input, this.options);
+        this.push(result);
+        cb();
+    }
+}

--- a/dist/utils.d.ts
+++ b/dist/utils.d.ts
@@ -1,0 +1,2 @@
+export declare function mask(value: string, char: string, keepLast?: number): string;
+export declare function replaceRange(text: string, start: number, end: number, replacement: string): string;

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -1,0 +1,10 @@
+export function mask(value, char, keepLast = 0) {
+    if (value.length <= keepLast) {
+        return char.repeat(value.length);
+    }
+    const maskedLength = value.length - keepLast;
+    return char.repeat(maskedLength) + value.slice(value.length - keepLast);
+}
+export function replaceRange(text, start, end, replacement) {
+    return text.slice(0, start) + replacement + text.slice(end);
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "redactory",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    "./package.json": "./package.json",
+    "./dist/index.js": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "node --test"
+  },
+  "bin": {
+    "redactory": "./bin/redactory.js"
+  }
+}

--- a/policy.yaml
+++ b/policy.yaml
@@ -1,0 +1,18 @@
+version: 1
+entityTypes:
+  - EMAIL
+  - PHONE
+  - SSN
+  - ICD10
+actions:
+  EMAIL: MASK
+  PHONE: MASK
+  SSN: REDACT
+  ICD10: ALLOW
+thresholds:
+  default: 0.7
+  SSN: 0.9
+mask:
+  char: "*"
+  keepLast: 4
+fallback: BLOCK

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -1,0 +1,3 @@
+declare module 'fs';
+declare module 'stream';
+declare module 'path';

--- a/src/detectors.ts
+++ b/src/detectors.ts
@@ -1,0 +1,41 @@
+export interface Entity {
+  type: string;
+  start: number;
+  end: number;
+  text: string;
+  score: number;
+  ruleId: string;
+}
+
+interface Pattern {
+  type: string;
+  regex: RegExp;
+  score: number;
+  ruleId: string;
+}
+
+const patterns: Pattern[] = [
+  { type: 'EMAIL', regex: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[A-Za-z]{2,}/g, score: 1, ruleId: 'regex-email' },
+  { type: 'PHONE', regex: /\b\d{3}[ -]?\d{3}[ -]?\d{4}\b/g, score: 0.9, ruleId: 'regex-phone' },
+  { type: 'SSN', regex: /\b\d{3}-\d{2}-\d{4}\b/g, score: 0.95, ruleId: 'regex-ssn' },
+  { type: 'ICD10', regex: /[A-TV-Z][0-9][0-9AB](\.[0-9A-TV-Z]{1,4})?/g, score: 0.8, ruleId: 'regex-icd10' }
+];
+
+export function detect(text: string): Entity[] {
+  const entities: Entity[] = [];
+  for (const p of patterns) {
+    for (const match of text.matchAll(p.regex)) {
+      const [value] = match;
+      const start = match.index || 0;
+      entities.push({
+        type: p.type,
+        start,
+        end: start + value.length,
+        text: value,
+        score: p.score,
+        ruleId: p.ruleId
+      });
+    }
+  }
+  return entities.sort((a, b) => a.start - b.start);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+export { Scrubber } from './scrubber.js';
+export { loadPolicy, validatePolicy } from './policy.js';
+export { ScrubTransform } from './transform.js';

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'fs';
+
+export interface Policy {
+  version: number;
+  entityTypes: string[];
+  actions: Record<string, 'MASK' | 'REDACT' | 'ALLOW'>;
+  thresholds: {
+    default: number;
+    [key: string]: number;
+  };
+  mask?: {
+    char: string;
+    keepLast: number;
+  };
+  fallback: 'BLOCK' | 'ALLOW' | 'MASK' | 'REDACT';
+}
+
+function parseYaml(text: string): any {
+  const obj: any = {};
+  const lines = text.split(/\r?\n/);
+  let currentKey: string | null = null;
+  for (const line of lines) {
+    if (/^\s*$/.test(line)) continue;
+    const m = /^([^:]+):\s*(.*)$/.exec(line);
+    if (m) {
+      const key = m[1].trim();
+      const value = m[2].trim();
+      if (value === '') {
+        currentKey = key;
+        obj[key] = [];
+      } else if (value.startsWith('[')) {
+        obj[key] = JSON.parse(value);
+      } else if (/^(true|false|\d+)$/.test(value)) {
+        obj[key] = JSON.parse(value);
+      } else {
+        obj[key] = value;
+      }
+      continue;
+    }
+    const arr = /^\s+-\s*(.*)$/.exec(line);
+    if (arr && currentKey) {
+      obj[currentKey].push(arr[1].trim());
+    }
+  }
+  return obj;
+}
+
+export function loadPolicy(file: string): Policy {
+  const text = readFileSync(file, 'utf8');
+  const data = file.endsWith('.json') ? JSON.parse(text) : parseYaml(text);
+  return data as Policy;
+}
+
+export function validatePolicy(policy: Policy): string[] {
+  const errors: string[] = [];
+  if (typeof policy.version !== 'number') errors.push('version');
+  if (!Array.isArray(policy.entityTypes)) errors.push('entityTypes');
+  if (typeof policy.actions !== 'object') errors.push('actions');
+  if (typeof policy.thresholds !== 'object') errors.push('thresholds');
+  if (!policy.fallback) errors.push('fallback');
+  return errors;
+}

--- a/src/scrubber.ts
+++ b/src/scrubber.ts
@@ -1,0 +1,90 @@
+import { Policy, loadPolicy } from './policy.js';
+import { Entity, detect } from './detectors.js';
+import { mask, replaceRange } from './utils.js';
+
+export interface ScrubOptions {
+  preview?: boolean;
+  explain?: boolean;
+}
+
+export interface ScrubResult {
+  result: string;
+  entities?: Entity[];
+  diff?: string;
+}
+
+export class Scrubber {
+  private policy: Policy;
+
+  constructor(policy: Policy) {
+    this.policy = policy;
+  }
+
+  static fromFile(path: string): Scrubber {
+    const p = loadPolicy(path);
+    return new Scrubber(p);
+  }
+
+  updatePolicy(policy: Policy): void {
+    this.policy = policy;
+  }
+
+  scrub(text: string, options: ScrubOptions = {}): ScrubResult {
+    const entities = detect(text);
+    let result = text;
+    let offset = 0;
+    const applied: Entity[] = [];
+    for (const ent of entities) {
+      const threshold = this.policy.thresholds[ent.type] ?? this.policy.thresholds.default;
+      if (ent.score < threshold) continue;
+      const action = this.policy.actions[ent.type] ?? this.policy.fallback;
+      let replacement = ent.text;
+      if (action === 'MASK') {
+        const maskChar = this.policy.mask?.char ?? '*';
+        const keepLast = this.policy.mask?.keepLast ?? 0;
+        replacement = mask(ent.text, maskChar, keepLast);
+      } else if (action === 'REDACT') {
+        replacement = '[REDACTED]';
+      } else if (action === 'ALLOW') {
+        continue;
+      }
+      result = replaceRange(result, ent.start + offset, ent.end + offset, replacement);
+      offset += replacement.length - (ent.end - ent.start);
+      applied.push(ent);
+    }
+
+    let diff: string | undefined;
+    if (options.preview && result !== text) {
+      diff = this.inlineDiff(text, result);
+    }
+
+    const res: ScrubResult = { result };
+    if (options.explain) res.entities = applied;
+    if (diff) res.diff = diff;
+    return res;
+  }
+
+  private inlineDiff(a: string, b: string): string {
+    // simple inline diff by marking removed text as [- -] and added as {+ +}
+    let i = 0;
+    let result = '';
+    while (i < a.length || i < b.length) {
+      if (a[i] === b[i]) {
+        result += a[i] ?? '';
+        i++;
+        continue;
+      }
+      const start = i;
+      let endA = start;
+      let endB = start;
+      while (a[endA] !== b[endB] && (endA < a.length || endB < b.length)) {
+        if (a[endA] !== undefined) endA++; if (b[endB] !== undefined) endB++;
+        if (a[endA] === b[endB]) break;
+      }
+      if (start !== endA) result += '[-' + a.slice(start, endA) + '-]';
+      if (start !== endB) result += '{+' + b.slice(start, endB) + '+}';
+      i = Math.max(endA, endB);
+    }
+    return result;
+  }
+}

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,0 +1,20 @@
+import { Transform } from 'stream';
+import { Scrubber, ScrubOptions } from './scrubber.js';
+
+export class ScrubTransform extends Transform {
+  private scrubber: Scrubber;
+  private options: ScrubOptions;
+
+  constructor(scrubber: Scrubber, options: ScrubOptions = {}) {
+    super({ objectMode: true });
+    this.scrubber = scrubber;
+    this.options = options;
+  }
+
+  _transform(chunk: any, _enc: any, cb: any) {
+    const input = typeof chunk === 'string' ? chunk : chunk.toString();
+    const { result } = this.scrubber.scrub(input, this.options);
+    this.push(result);
+    cb();
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+export function mask(value: string, char: string, keepLast: number = 0): string {
+  if (value.length <= keepLast) {
+    return char.repeat(value.length);
+  }
+  const maskedLength = value.length - keepLast;
+  return char.repeat(maskedLength) + value.slice(value.length - keepLast);
+}
+
+export function replaceRange(text: string, start: number, end: number, replacement: string): string {
+  return text.slice(0, start) + replacement + text.slice(end);
+}

--- a/tests/scrubber.test.js
+++ b/tests/scrubber.test.js
@@ -1,0 +1,21 @@
+import assert from 'assert/strict';
+import { Scrubber } from '../dist/index.js';
+
+const policy = {
+  version: 1,
+  entityTypes: ['EMAIL', 'PHONE', 'SSN', 'ICD10'],
+  actions: { EMAIL: 'MASK', PHONE: 'MASK', SSN: 'REDACT', ICD10: 'ALLOW' },
+  thresholds: { default: 0.7, SSN: 0.9 },
+  mask: { char: '*', keepLast: 4 },
+  fallback: 'BLOCK'
+};
+
+const scrubber = new Scrubber(policy);
+
+export default function test() {
+  const text = 'Contact me at john@example.com or 555-123-4567. SSN 123-45-6789.';
+  const { result } = scrubber.scrub(text);
+  assert.ok(!result.includes('john@example.com'));
+  assert.ok(!result.includes('555-123-4567'));
+  assert.ok(result.includes('[REDACTED]'));
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Node",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": [
+    "src",
+    "src/**/*.ts",
+    "src/**/*.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
## Summary
- add redactory scrubber core implementation in TypeScript
- provide CLI with scrub/preview/ingest/policy validate
- include default YAML policy
- document usage in README
- add node-based test

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688915d66af8832998d2b1873571225d