### PR TITLE
Add synthetic data for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,12 @@ const scrubber = new Scrubber(policy);
 const { result } = scrubber.scrub('Contact me at john@example.com');
 console.log(result);
 ```
+
+## Synthetic Test Data
+
+A sample file containing fabricated sensitive data is available at `synthetic-data/sample.txt` for quick testing.
+Run the CLI to scrub the file:
+
+```bash
+npx redactory scrub synthetic-data/sample.txt
+```

--- a/synthetic-data/sample.txt
+++ b/synthetic-data/sample.txt
@@ -1,0 +1,3 @@
+Hello, I'm Jane Doe. My email is jane.doe@example.com and you can call me at 222-333-4444.
+My old SSN is 987-65-4321 and ICD10 code is A15.0.
+Reach John at john.smith@demo.co or 333-444-5555. SSN 111-22-3333.

--- a/tests/synthetic-data.test.js
+++ b/tests/synthetic-data.test.js
@@ -1,0 +1,24 @@
+import assert from 'assert/strict';
+import { readFileSync } from 'fs';
+import { Scrubber } from '../dist/index.js';
+
+const policy = {
+  version: 1,
+  entityTypes: ['EMAIL', 'PHONE', 'SSN', 'ICD10'],
+  actions: { EMAIL: 'MASK', PHONE: 'MASK', SSN: 'REDACT', ICD10: 'ALLOW' },
+  thresholds: { default: 0.7, SSN: 0.9 },
+  mask: { char: '*', keepLast: 4 },
+  fallback: 'BLOCK'
+};
+
+const scrubber = new Scrubber(policy);
+
+export default function test() {
+  const text = readFileSync('synthetic-data/sample.txt', 'utf8');
+  const { result } = scrubber.scrub(text);
+  assert.ok(!result.includes('jane.doe@example.com'));
+  assert.ok(!result.includes('222-333-4444'));
+  assert.ok(!result.includes('987-65-4321'));
+  assert.ok(!result.includes('john.smith@demo.co'));
+  assert.ok(result.includes('[REDACTED]'));
+}


### PR DESCRIPTION
## Summary
- provide sample synthetic text with emails, phones and SSNs
- document how to scrub the sample file
- add a unit test that uses the new file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889195789348329a45a993d60ac89bb