### PR TITLE
Add TypeScript and bundled type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,9 @@
   },
   "bin": {
     "redactory": "./bin/redactory.js"
+  },
+  "types": "dist/index.d.ts",
+  "devDependencies": {
+    "typescript": "^5.4.5"
   }
 }


### PR DESCRIPTION
## Summary
- add `typescript` as a dev dependency
- expose bundled declarations with `types` entry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688924a139708329834de0c32df99306