### PR TITLE
Add tests for CLI and policy validation

### DIFF
--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,0 +1,33 @@
+import assert from 'assert/strict';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, writeFileSync, copyFileSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+export default function test() {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'redactory-'));
+  try {
+    // policy validate with valid policy
+    let res = spawnSync('node', ['bin/redactory.js', 'policy', 'validate', 'policy.yaml'], { encoding: 'utf8' });
+    assert.equal(res.status, 0);
+    assert.ok(res.stdout.includes('Policy valid'));
+
+    // policy validate with invalid policy
+    const invalidPath = join(tmpDir, 'invalid.json');
+    writeFileSync(invalidPath, JSON.stringify({ version: '1' }));
+    res = spawnSync('node', ['bin/redactory.js', 'policy', 'validate', invalidPath], { encoding: 'utf8' });
+    assert.notEqual(res.status, 0);
+    assert.ok(res.stderr.includes('Policy invalid'));
+
+    // scrub command modifies file in place
+    const filePath = join(tmpDir, 'sample.txt');
+    copyFileSync('synthetic-data/sample.txt', filePath);
+    res = spawnSync('node', ['bin/redactory.js', 'scrub', filePath], { encoding: 'utf8' });
+    assert.equal(res.status, 0);
+    const scrubbed = readFileSync(filePath, 'utf8');
+    assert.ok(!scrubbed.includes('jane.doe@example.com'));
+    assert.ok(scrubbed.includes('[REDACTED]'));
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}

--- a/tests/validate-policy.test.js
+++ b/tests/validate-policy.test.js
@@ -1,0 +1,22 @@
+import assert from 'assert/strict';
+import { validatePolicy } from '../dist/index.js';
+
+export default function test() {
+  const valid = {
+    version: 1,
+    entityTypes: ['EMAIL'],
+    actions: { EMAIL: 'MASK' },
+    thresholds: { default: 0.5 },
+    mask: { char: '*', keepLast: 2 },
+    fallback: 'REDACT'
+  };
+  assert.deepEqual(validatePolicy(valid), []);
+
+  const invalid = { entityTypes: 'EMAIL' };
+  const errors = validatePolicy(invalid);
+  assert.ok(errors.includes('version'));
+  assert.ok(errors.includes('entityTypes'));
+  assert.ok(errors.includes('actions'));
+  assert.ok(errors.includes('thresholds'));
+  assert.ok(errors.includes('fallback'));
+}


### PR DESCRIPTION
## Summary
- add a CLI test covering `policy validate` and `scrub`
- add unit tests for `validatePolicy` with valid and invalid objects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688924a56c908329af825bb82b00fdb4